### PR TITLE
Restore RFC2119 terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1686,9 +1686,11 @@
   <p>
 Gregg Kellogg,
 Ivan Herman,
+Jens Oliver Meiert,
 Léonie Watson,
 Manu Sporny,
 Tab Atkins,
+Tavis Tucker,
 Xiaoqian Wu,
 Yves Lafon.
   </p>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,9 @@
 
   <section id="conformance">
 
+  <p>The key words "must", "must not", "should", "should not", and "may" in the normative parts of this document
+  are to be interpreted as described in RFC2119. [[!RFC2119]]</p>
+
   <p>Requirements phrased in the imperative as part of algorithms (such as "strip any leading space
   characters" or "return false and abort these steps") are to be interpreted with the meaning of the
   key word ("must", "should", "may", etc) used in introducing the algorithm.</p>


### PR DESCRIPTION
(The ones we actually use).

Somewhere in the conversion processes they got lost.