### PR TITLE
Prefix typed item's properties with a URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
   and content management systems can find and use information from documents, if it is marked up in a known way.</p>
 
   <p>Microdata provides a simple mechanism to label content in a document,
-    so it can be processed as a set of <a data-lt="concept item">items</a>,
+    so it can be processed as a set of <a data-lt="concept item">items</a>
     described by name-value pairs.</p>
 
   <p>Each name-value pair identifies a <a data-lt="item property">property</a> of the item, and a <a data-lt="property value">value</a> of that property.</p>
@@ -273,7 +273,7 @@
   
   </div>
 
-  <p>Markup without microdata attributes has no effect on microdata.</p>
+  <p>Markup other than microdata attributes has no effect on microdata.</p>
 
   <div class="example">
 
@@ -363,10 +363,9 @@
 
   <div class="example">
 
-   <p>In this example, the item has one property, <var>logo</var>, whose value is a URL that will begin with the
-    current location of the document, and end with <samp>/our-logo.png</samp>:</p>
+   <p>In this example, the item has one property, <var>logo</var>, whose value is a URL based on the location of the page, and ending with <samp>our-logo.png</samp>:</p>
 
-   <pre>&lt;div itemscope&gt; itemtype="http://schema.org/LocalBusiness"
+   <pre>&lt;div itemscope itemtype="https://schema.org/LocalBusiness"&gt;
  &lt;img itemprop="logo" src="our-logo.png" alt="Our Company"&gt;
 &lt;/div&gt;</pre>
 
@@ -374,7 +373,7 @@
      is ignored. To provide that as a value, repeat it in a <a>content</a> attribute. In the following example, the value
      of the <var>name</var> property is <samp>The Company</samp>:</p>
 
-   <pre>&lt;div itemscope&gt; itemtype="http://schema.org/LocalBusiness"
+   <pre>&lt;div itemscope itemtype="https://schema.org/LocalBusiness"&gt;
  &lt;img itemprop="name" src="our-logo.png"
      content="The Company" alt="Our Company"&gt;
 &lt;/div&gt;</pre>
@@ -388,11 +387,11 @@
 
    <p>Here a rating of <samp>3.5</samp> is given using a <code>meter</code> element.</p>
 
-   <pre>&lt;div itemscope itemtype="http://schema.org/Product"&gt;
+   <pre>&lt;div itemscope itemtype="https://schema.org/Product"&gt;
  &lt;span itemprop="name"&gt;Panasonic White 60L Refrigerator&lt;/span&gt;
  &lt;img src="panasonic-fridge-60l-white.jpg" alt=""&gt;
   &lt;div itemprop="aggregateRating"
-       itemscope itemtype="http://schema.org/AggregateRating"&gt;
+       itemscope itemtype="https://schema.org/AggregateRating"&gt;
    &lt;meter itemprop="ratingValue" min=0 value=3.5 max=5&gt;Rated 3.5/5&lt;/meter&gt;
    (based on &lt;span itemprop="reviewCount"&gt;11&lt;/span&gt; customer reviews)
   &lt;/div&gt;
@@ -502,7 +501,7 @@
 
   <div class="example">
 
-   <p>The following two examples are exactly the same as microdata:</p>
+   <p>The following two examples are exactly the same microdata, because they produce exactly the same information when processed:</p>
 
    <pre>&lt;figure&gt;
  &lt;img src="castle.jpeg"&gt;
@@ -539,11 +538,11 @@
 
   <p>The type for an <a data-lt="concept item">item</a> is given as the value of an
   <code><a>itemtype</a></code> attribute on the same element as the
-  <code><a>itemscope</a></code> attribute.</p>
+  <code><a>itemscope</a></code> attribute. The value is a URL, which determines the <a>vocabulary identifier</a> for properties</p>
 
   <div class="example">
 
-   <p>Here, the item's type is "http://example.org/animals#cat":</p>
+   <p>Assuming a page at http://example.net/some/dataexample contains the following code:</p>
 
 <pre>&lt;section itemscope itemtype="http://example.org/animals#cat"&gt;
  &lt;h1 itemprop="name"&gt;Hedral&lt;/h1&gt;
@@ -552,8 +551,18 @@
  &lt;img itemprop="img" src="hedral.jpeg" alt="" title="Hedral, age 18 months"&gt;
 &lt;/section&gt;</pre>
 
-   <p>In this example the "http://example.org/animals#cat" item has three properties, a "name"
-   ("Hedral"), a "desc" ("Hedral is..."), and an "img" ("hedral.jpeg").</p>
+   <p>The item's type is "http://example.org/animals#cat"</p>
+
+   <p>In this example the "http://example.org/animals#cat" item has three properties:<p>
+
+   <dl>
+    <dt><samp>http://example.org/animals#name</samp></dt>
+     <dd>"Hedral"</dd>
+    <dt><samp>http://example.org/animals#desc</samp></dt>
+     <dd>Hedral is a male american domestic shorthair, with a fluffy black fur with white paws and belly.
+    <dt><samp>http://example.org/animals#img</samp></dt>
+     <dd>hedral.jpeg</dd>
+   </dl>
 
   </div>
 
@@ -561,14 +570,12 @@
   "class" given for an item with the type "http://census.example/person" might refer to the economic
   class of an individual, while a property named "class" given for an item with the type
   "http://example.com/school/teacher" might refer to the classroom a teacher has been assigned.
-  Several types can share a vocabulary. For example, the types
+  A vocabulary may define several types. For example, the types
   "<code>http://example.org/people/teacher</code>" and "<code>http://example.org/people/engineer</code>"
-  could be defined to use the same vocabulary
-  (though maybe some properties would not be especially useful in both cases, e.g. maybe the
-  "<code>http://example.org/people/engineer</code>" type might not typically be used with the
-  "<code>classroom</code>" property). Multiple types defined to use the same vocabulary can
-  be given for a single item by listing the URLs as a space-separated list in the attribute' value.
-  An item cannot be given two types if they do not use the same vocabulary, however.</p>
+  could be defined in the same vocabulary. Some properties might not be especially useful in both cases:
+  the "<code>classroom</code>" property  might not be meaningful with the "<code>http://example.org/people/engineer</code>" type.
+  Multiple types from the same vocabulary can be given for a single item by listing the URLs, separated by spaces,
+  in the attribute's value. An item cannot be given two types if they do not use the same vocabulary, however.</p>
 
 </section>
 
@@ -614,9 +621,8 @@
 <h3>Selecting names when defining vocabularies</h3>
 
   <p><i>This section is non-normative.</i></p>
-  <p>Using microdata means using a vocabulary. For some purposes, an ad-hoc vocabulary is adequate.
-  For others, a vocabulary will need to be designed. Where possible, authors are encouraged to
-  re-use existing vocabularies, as this makes content re-use easier.</p>
+  <p>Using microdata means using a vocabulary. For some purposes an ad-hoc vocabulary is adequate, 
+  but authors are encouraged to re-use existing vocabularies to make content re-use easier.</p>
 
   <p>When designing new vocabularies, identifiers can be created either using
   <a>URL</a>s, or, for properties, as plain words (with no dots or colons). For URLs,
@@ -642,11 +648,11 @@
 
   <div class="example">
 
-   <p>Here, an item is an "http://example.org/animals#cat", and most of the properties have names
-   that are words defined in the context of that type. There are also a few additional properties
-   whose names come from other vocabularies.</p>
+   <p>Here, an item in the page http://example.net/some/dataexample is an "http://example.org/animals/cat",
+   and most of the properties have names defined in the context of that type.
+   There are also a few additional properties whose names come from other vocabularies.</p>
 
-<pre>&lt;section itemscope itemtype="http://example.org/animals#cat"&gt;
+<pre>&lt;section itemscope itemtype="http://myvocab.example.org/animals/cat"&gt;
  &lt;h1 itemprop="name http://example.com/fn"&gt;Hedral&lt;/h1&gt;
  &lt;p itemprop="desc"&gt;Hedral is a male american domestic
  shorthair, with a fluffy &lt;span
@@ -655,34 +661,23 @@
  &lt;img itemprop="img" src="hedral.jpeg" alt="" title="Hedral, age 18 months"&gt;
 &lt;/section&gt;</pre>
 
-   <p>This example has one item with the type "http://example.org/animals#cat" and the following
+   <p>This example has one item with the type "http://myvocab.example.org/animals/cat" and the following
    properties:</p>
 
-   <table>
-    <thead>
-     <tr>
-      <td>Property
-      </td><td>Value
-    </td></tr></thead><tbody>
-     <tr>
-      <td>name
-      </td><td>Hedral
-     </td></tr><tr>
-      <td>http://example.com/fn
-      </td><td>Hedral
-     </td></tr><tr>
-      <td>desc
-      </td><td>Hedral is a male american domestic shorthair, with a fluffy black fur with white paws and belly.
-     </td></tr><tr>
-      <td>http://example.com/color
-      </td><td>black
-     </td></tr><tr>
-      <td>http://example.com/color
-      </td><td>white
-     </td></tr><tr>
-      <td>img
-      </td><td>.../hedral.jpeg
-   </td></tr></tbody></table>
+   <dl>
+    <dt>http://myvocab.example.org/animals/name</dt>
+     <dd>Hedral<dd>
+    <dt>http://example.com/fn</dt>
+     <dd>Hedral</dd>
+    <dt>http://myvocab.example.org/animals/desc</dt>
+     </dd>Hedral is a male american domestic shorthair, with a fluffy black fur with white paws and belly.</dd>
+    <dt>http://example.com/color</dt>
+     <dd>black</dd>
+    <dt>http://example.com/color</dt>
+     <dd>white</dd></tr><tr>
+    <dt>http://myvocab.example.org/animals/img</dt>
+     <dd>http://example.net/some/hedral.jpeg</dd>
+   </dl>
 
   </div>
 </section>
@@ -727,7 +722,7 @@
   <p>The <code><a>itemtype</a></code> attribute, if specified, must have a value that
   is an <a>unordered set of unique space-separated tokens</a> that are
   <span>case-sensitive</span>, each of which is a <a>valid absolute
-  URL</a>, and all of which are defined to use the same vocabulary. The attribute's value must
+  URL</a>, and all of which are in the same vocabulary. The attribute's value must
   have at least one token.</p>
 
   <p>The <dfn id="item-types">item types</dfn> of an <a data-lt="concept item">item</a> are the tokens obtained
@@ -736,22 +731,34 @@
   in this way finds no tokens, the <a data-lt="concept item">item</a> is said to have no
   <a href="#item-types">item types</a>.</p>
 
-  <p>The <a href="#item-types">item types</a> must all be types defined in <span title="other applicable
-  specifications">applicable specifications</span> and must all be defined to use the same
-  vocabulary.</p>
+  <p>The <a href="#item-types">item types</a> determine the <dfn>vocabulary identifier</dfn>. This is a URL
+  that is prepended to <a>property names</a>, which identifies them as part of their vocabulary.
+  The value of the vocabulary identifier for an item is determined as follows:</p>
 
+  <ul>
+   <li>Let <var>potential values</var> be an empty array of URLs.</li>
+   <li>Let <var>tokens</a> be the value of the <a>itemtype</a> attribute, split on spaces.</li>
+   <li>For each value of <var>tokens</var>: <dl class="switch">
+    <dt>If there is a NUMBER SIGN Ux0023 ("#") in the value</dt>
+     <dd>Append the substring of the value from the beginning to the <em>first</em> NUMBER SIGN Ux0023 ("#") to
+      <var>potential values</var></dd>
+    <dt>Otherwise, if there is a SOLIDUS Ux002F ("/") in the value</dt>
+     <dd>Append the substring of the value from the beginning to the <em>last</em> SOLIDUS Ux002F ("/") to
+      <var>potential values</var></dd>
+    <dt>Otherwise</dt>
+     <dd>Append a SOLIDUS Ux002F ("/") to the value, and append the resulting string to <var>potential values</var></dd>
+    </dl></li>
+   <li>If there is only one unique value in <var>potential values</value> return that value. Otherwise return the 
+    first item in <var>potential values</var>.</li>
+  </li>
 
-   <p>Except if otherwise specified by that specification, the <a data-lt="URL">URLs</a> given
-   as the <a href="#item-types">item types</a> should not be automatically dereferenced.</p>
+   <p>User agents must not automatically dereference <em>unknown</em> <a data-lt="URL">URLs</a> given as <a>item types</a>
+   and <a>property names</a>. These URLs are <i>a priori</i> opaque identifiers.</p>
 
    <p class="note">A specification could define that its <a href="#item-types" title="item types">item type</a>
-   can be derefenced to provide the user with help information, for example. In fact, vocabulary
-   authors are encouraged to provide useful information at the given <a href="#url">URL</a>.</p>
-
-   <p><a href="#item-types">Item types</a> are opaque identifiers, and user agents must not dereference unknown
-   <a href="#item-types">item types</a>, or otherwise deconstruct them, in order to determine how to process
-   <a data-lt="concept item">items</a> that use them.</p>
-
+   can be derefenced to provide the user with help information. Vocabulary authors are encouraged to provide useful information
+   at the given <a href="#url">URL</a>, either in prose or a formal language such as RDF. User agents are
+   </p>
 
   <p>The <code><a>itemtype</a></code> attribute must not be specified on elements
   that do not have an <code><a>itemscope</a></code> attribute specified.</p>
@@ -901,14 +908,32 @@
   that contain "." (U+002E) characters, ":" (U+003A) characters,
   nor <a>space characters</a> (defined in [[!HTML52]] as U+0020, U+0009, U+000A, U+000C, and U+000D).</p>
 
-  <p>The <dfn>property names</dfn> of an element are the tokens that the element's
-  <code><a>itemprop</a></code> attribute is found to contain
-  when its value is <a data-lt="split a string on spaces">split on spaces</a>,
-  with the order preserved but with duplicates removed leaving only the first occurrence of each name.</p>
+  <p>The <dfn>property names</dfn> of an element are determined as follows:</p>
+
+  <ul>
+
+   <li>Let <var>tokens</var> be the values of the <a>itemprop</a> attribute,
+     <a data-lt="split a string on spaces">Split on spaces</a>.</li>
+   <li>Let <var>properties</var> be an empty array of strings.</li>
+
+   <li>For each value of <var>token</var>, in order: <dl class="switch">
+    <dt>If the value is a repeated occurrence of an earlier value</dt>
+     <dd>discard it and process the next value</dd>
+    <dt>If the value is an <a>absolute URL</a></dt>
+     <dd>append it to <var>properties</var>, then process the next value</dd> 
+    <dt>Otherwise, if the the element is a <a>typed item</a>:</dt>
+     <dd>Append the value to the <a>vocabulary identifier</a> for the item. If the the resulting value
+      does not match any value in <var>properties</var>, then append it to <var>properties</var>, 
+      and process the next value.</dd>
+    <dt>Otherwise</dt>
+     <dd>append the value to <var>properties</var> and process the next value.</dd></li>
+
+   <li>If <var>properties</var> is not empty, return <var>properties</var>.</li> 
+  </ul>
 
   <p>Within an <a data-lt="concept item">item</a>, the properties are unordered with respect to
   each other, except for properties with the same name, which are ordered in the order they are
-  given by the algorithm that defines <a href="#the-properties-of-an-item">the properties of an item</a>.</p>
+  given by the algorithm that defines <a>the properties of an item</a>.</p>
 
   <div class="example">
 
@@ -1330,7 +1355,7 @@
 
    <pre>&lt;!DOCTYPE HTML&gt;
 &lt;title&gt;My Blog&lt;/title&gt;
-&lt;article itemscope itemtype="http://schema.org/BlogPosting"&gt;
+&lt;article itemscope itemtype="https://schema.org/BlogPosting"&gt;
  &lt;header&gt;
   &lt;h1 itemprop="headline"&gt;Progress report&lt;/h1&gt;
   &lt;p&gt;&lt;time itemprop="datePublished" datetime="2013-08-29"&gt;today&lt;/time&gt;&lt;/p&gt;
@@ -1340,20 +1365,20 @@
  putting his head in, but we got it down.&lt;/p&gt;
  &lt;section&gt;
   &lt;h1&gt;Comments&lt;/h1&gt;
-  &lt;article itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c1"&gt;
+  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c1"&gt;
    &lt;link itemprop="url" href="#c1"&gt;
    &lt;footer&gt;
-    &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
+    &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
      &lt;span itemprop="name"&gt;Greg&lt;/span&gt;
     &lt;/span&gt;&lt;/p&gt;
     &lt;p&gt;&lt;time itemprop="commentTime" datetime="2013-08-29"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
    &lt;/footer&gt;
    &lt;p&gt;Ha!&lt;/p&gt;
   &lt;/article&gt;
-  &lt;article itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c2"&gt;
+  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c2"&gt;
    &lt;link itemprop="url" href="#c2"&gt;
    &lt;footer&gt;
-    &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
+    &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
      &lt;span itemprop="name"&gt;Charlotte&lt;/span&gt;
     &lt;/span&gt;&lt;/p&gt;
     &lt;p&gt;&lt;time itemprop="commentTime" datetime="2013-08-29"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;
@@ -1369,19 +1394,19 @@
    <pre>{
   "items": [
     {
-      "type": [ "http://schema.org/BlogPosting" ],
+      "type": [ "https://schema.org/BlogPosting" ],
       "properties": {
         "headline": [ "Progress report" ],
         "datePublished": [ "2013-08-29" ],
         "url": [ "http://blog.example.com/progress-report?comments=0" ],
         "comment": [
           {
-            "type": [ "http://schema.org/UserComments" ],
+            "type": [ "https://schema.org/UserComments" ],
             "properties": {
               "url": [ "http://blog.example.com/progress-report#c1" ],
               "creator": [
                 {
-                  "type": [ "http://schema.org/Person" ],
+                  "type": [ "https://schema.org/Person" ],
                   "properties": {
                     "name": [ "Greg" ]
                   }
@@ -1391,12 +1416,12 @@
             }
           },
           {
-            "type": [ "http://schema.org/UserComments" ],
+            "type": [ "https://schema.org/UserComments" ],
             "properties": {
               "url": [ "http://blog.example.com/progress-report#c2" ],
               "creator": [
                 {
-                  "type": [ "http://schema.org/Person" ],
+                  "type": [ "https://schema.org/Person" ],
                   "properties": {
                     "name": [ "Charlotte" ]
                   }

--- a/index.html
+++ b/index.html
@@ -1665,6 +1665,8 @@
   <p>Changes made between the current draft and the <a href="https://www.w3.org/TR/2017/WD-microdata-20170504/">First Public Working Draft</a>:</p>
 
   <ul>
+    <li>Add a mechanism to determine the URL that is a <a>vocabulary identifier</a>,
+      and use it as the start of the property name for <a>typed items</a>
    <li>Remove section "microdata and other namespaces" which implied that microdata would not work in other namespaces. Because it does.</li>
    <li>Allow the <code>content</code> attribute on any element where an <a>itemprop</a> attribute is present,
      to provide a readable value for a property.</li>


### PR DESCRIPTION
Fix #41 

If an `itemtype` has a "#" then the **first** one marks the end of the vocabulary identifier, otherwise
if it has a "/" the **last one** is the end of the vocab identifier, otherwise
Append "/" to the end.

For typed items, non-absolute URLs are appended to the vocabulary identifier to form property names.