### PR TITLE
Example with blog post comments: Schema.org 'Comment' instead of 'UserComments'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1353,7 +1353,7 @@
  putting his head in, but we got it down.&lt;/p&gt;
  &lt;section&gt;
   &lt;h1&gt;Comments&lt;/h1&gt;
-  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c1"&gt;
+  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/Comment" id="c1"&gt;
    &lt;link itemprop="url" href="#c1"&gt;
    &lt;footer&gt;
     &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
@@ -1363,7 +1363,7 @@
    &lt;/footer&gt;
    &lt;p&gt;Ha!&lt;/p&gt;
   &lt;/article&gt;
-  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c2"&gt;
+  &lt;article itemprop="comment" itemscope itemtype="https://schema.org/Comment" id="c2"&gt;
    &lt;link itemprop="url" href="#c2"&gt;
    &lt;footer&gt;
     &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
@@ -1389,7 +1389,7 @@
         "url": [ "http://blog.example.com/progress-report?comments=0" ],
         "comment": [
           {
-            "type": [ "https://schema.org/UserComments" ],
+            "type": [ "https://schema.org/Comment" ],
             "properties": {
               "url": [ "http://blog.example.com/progress-report#c1" ],
               "creator": [
@@ -1404,7 +1404,7 @@
             }
           },
           {
-            "type": [ "https://schema.org/UserComments" ],
+            "type": [ "https://schema.org/Comment" ],
             "properties": {
               "url": [ "http://blog.example.com/progress-report#c2" ],
               "creator": [

--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,7 @@
     &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
      &lt;span itemprop="name"&gt;Greg&lt;/span&gt;
     &lt;/span&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;time itemprop="commentTime" datetime="2013-08-29"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;time itemprop="dateCreated" datetime="2013-08-29"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
    &lt;/footer&gt;
    &lt;p&gt;Ha!&lt;/p&gt;
   &lt;/article&gt;
@@ -1369,7 +1369,7 @@
     &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
      &lt;span itemprop="name"&gt;Charlotte&lt;/span&gt;
     &lt;/span&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;time itemprop="commentTime" datetime="2013-08-29"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;time itemprop="dateCreated" datetime="2013-08-29"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;
    &lt;/footer&gt;
    &lt;p&gt;When you say "we got it down"...&lt;/p&gt;
   &lt;/article&gt;
@@ -1400,7 +1400,7 @@
                   }
                 }
               ],
-              "commentTime": [ "2013-08-29" ]
+              "dateCreated": [ "2013-08-29" ]
             }
           },
           {
@@ -1415,7 +1415,7 @@
                   }
                 }
               ],
-              "commentTime": [ "2013-08-29" ]
+              "dateCreated": [ "2013-08-29" ]
             }
           }
         ]


### PR DESCRIPTION
The example uses the [`comment`](https://schema.org/comment) property, which expects [`Comment`](https://schema.org/Comment), not [`UserComments`](https://schema.org/UserComments) (which is "an old way").

As `Comment` doesn’t define the `commentTime` property, using `dateCreated` instead.