### PR TITLE
Example had 'ref' element & ''itemred' attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,8 +997,8 @@
 
      <p>For the following code:</p>
 
-<pre><code>&lt;div itemscope itemtype="http://example.com/a"&gt; &lt;ref itemred="x"&gt; &lt;/div&gt;
-&lt;div itemscope itemtype="http://example.com/b"&gt; &lt;ref itemref="x"&gt; &lt;/div&gt;
+<pre><code>&lt;div itemscope itemtype="http://example.com/a" itemref="x"&gt;&lt;/div&gt;
+&lt;div itemscope itemtype="http://example.com/b" itemref="x"&gt;&lt;/div&gt;
 &lt;meta id="x" itemprop="z" content=""&gt;</code></pre>
 
      <p>The author should be certain that <samp>z</samp> is a valid property name for both the


### PR DESCRIPTION
An example in section 5.3 uses a non-existing `ref` element with an `itemred` (instead of `itemref`) attribute.